### PR TITLE
Fixed small typo

### DIFF
--- a/gent.for
+++ b/gent.for
@@ -2440,7 +2440,7 @@ C
       Else
          Write( OutFl, 8 )  AlnLen, SqTyp1(NSqTyp)
          Do 310 n = 1, NS, 1
-            Write( OutFl, 9 ), Name(n), LSN(n), n, SeqWt(n)
+            Write( OutFl, 9 ) Name(n), LSN(n), n, SeqWt(n)
   310       continue
          Write( OutFl, 10 )
          NBlock = ( AlnLen + 49 ) / 50


### PR DESCRIPTION
@ropelews this PR fixes a really small typo.

Without it the code compiles but produces the error message

```
gfortran -o gent gent.for
gent.for:2443:29:

             Write( OutFl, 9 ), Name(n), LSN(n), n, SeqWt(n)
                             1
Warning: Legacy Extension: Comma before i/o item list at (1)

````